### PR TITLE
Use correct cerces version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- 3rd party dependencies -->
+        <xercesImpl.version>2.9.1</xercesImpl.version>
     </properties>
 
     <dependencies>
@@ -67,11 +69,19 @@
             <artifactId>opengl</artifactId>
             <version>0.1.1</version>
         </dependency>
+
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <version>1.4.8</version>
         </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>${xercesImpl.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
To support the reading of defaults, resetting the xml parser is required.
To support this, an updated runtime dependency of `xercesImpl` is necessary.